### PR TITLE
Hotfix: only import list if the user clicks import

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,7 @@
             <label for="list-import">You can also import a list:</label>
             <br>
             <input type="file" id="list-import" accept=".txt">
+            <button id="list-import-button">Import List</button>
             <br><br>
             <button id="list-export">Export list</button>
             <br><br>

--- a/docs/index.js
+++ b/docs/index.js
@@ -16,6 +16,7 @@ let beginQuizButton = document.getElementById('begin-quiz');
 let outlineCheckbox = document.getElementById('show-char');
 
 let listUploadInput = document.getElementById('list-import');
+let listImportButton = document.getElementById('list-import-button'); // The actual thing that the user has to click
 let listExportButton = document.getElementById('list-export');
 
 /***************
@@ -226,15 +227,16 @@ LIST IMPORTING AND EXPORTING
 
 async function importList() {
     const reader = new FileReader();
-    const listFile = this.files[0];
+    const listFile = listUploadInput.files[0];
 
     reader.addEventListener('load', (event) => {
         const listRaw = sanitize(event.target.result);
         const inputCharArray = listRaw.split('\n');
 
-        for (const char of inputCharArray) {
+        for (const charRaw of inputCharArray) {
+            const char = charRaw.trim()
             validateCharacter(char).then(charExists => {
-                if (charExists) {
+                if (charExists && !charList.includes(char)) {
                     charList.push(char);
 
                     let listItem = document.createElement('li');
@@ -291,5 +293,5 @@ beginQuizButton.addEventListener('click', e => {
 
 outlineCheckbox.addEventListener('click', checkboxChanged);
 
-listUploadInput.addEventListener('change', importList);
+listImportButton.addEventListener('click', importList);
 listExportButton.addEventListener('click', exportList);


### PR DESCRIPTION
Bypasses issue where in production the characters aren't added to the list when a file is selected.

Instead now the characters are added to the list when an "Import List" button is clicked, not when the user selects a file.

This works on local machine